### PR TITLE
Build fixes for newer Linux environments

### DIFF
--- a/toolchain/binutils/Makefile.in
+++ b/toolchain/binutils/Makefile.in
@@ -185,7 +185,7 @@ MAKEINFO=@MAKEINFO@
 USUAL_MAKEINFO = `if [ -f $$r/texinfo/makeinfo/makeinfo ] ; \
 	then echo $$r/texinfo/makeinfo/makeinfo ; \
 	else if (makeinfo --version \
-	  | egrep 'texinfo[^0-9]*([1-3][0-9]|4\.[2-9]|[5-9])') >/dev/null 2>&1; \
+	  | egrep 'texinfo[^0-9]*([1-3][0-9]|4\.[2-9])') >/dev/null 2>&1; \
         then echo makeinfo; else echo $$s/missing makeinfo; fi; fi`
 
 # This just becomes part of the MAKEINFO definition passed down to

--- a/toolchain/build.sh
+++ b/toolchain/build.sh
@@ -14,7 +14,7 @@ rm -rf gccbuild
 mkdir gccbuild
 cd gccbuild
 #../gcc/configure --target=zpu-elf --prefix=`pwd`/../install --enable-languages=c,c++ --with-gnu-as --with-gnu-ld --with-newlib --disable-shared --enable-newlib -v --enable-checking=misc,tree,rtl,rtlflag,gc,gcac,fold  --disable-multilib --disable-threads --enable-sjlj-exceptions --enable-libstdcxx-allocator=malloc
-../gcc/configure --target=zpu-elf --prefix=`pwd`/../install --enable-languages=c --with-gnu-as --with-gnu-ld --with-newlib --disable-shared --enable-newlib -v --enable-checking=misc,tree,rtl,rtlflag,gc,gcac,fold  --disable-multilib --disable-threads --enable-sjlj-exceptions --enable-libstdcxx-allocator=malloc
+../gcc/configure --target=zpu-elf --prefix=`pwd`/../install --enable-languages=c,c++ --with-gnu-as --with-gnu-ld --with-newlib --disable-shared --enable-newlib -v --enable-checking=misc,tree,rtl,rtlflag,gc,gcac,fold  --disable-multilib --disable-threads --enable-sjlj-exceptions --enable-libstdcxx-allocator=malloc
 make
 make install
 

--- a/toolchain/build.sh
+++ b/toolchain/build.sh
@@ -3,6 +3,7 @@ set -e
 rm -rf build
 mkdir build
 cd build
+export CFLAGS=-D_FORTIFY_SOURCE=0
 ../binutils/configure --target=zpu-elf --prefix=`pwd`/../install
 make
 make install

--- a/toolchain/gcc/gcc/c-parse.y
+++ b/toolchain/gcc/gcc/c-parse.y
@@ -591,7 +591,7 @@ primary:
 	IDENTIFIER
 		{
 		  if (yychar == YYEMPTY)
-		    yychar = YYLEX;
+		    yychar = yylex();
 		  $$ = build_external_ref ($1, yychar == '(');
 		}
 	| CONSTANT
@@ -1647,7 +1647,7 @@ enum_head:
 
 structsp_attr:
 	  struct_head identifier '{'
-		{ $$ = start_struct (RECORD_TYPE, $2);
+		{ $<ttype>$ = start_struct (RECORD_TYPE, $2);
 		  /* Start scope of tag before parsing components.  */
 		}
 	  component_decl_list '}' maybe_attribute
@@ -1658,7 +1658,7 @@ structsp_attr:
 				      nreverse ($3), chainon ($1, $5));
 		}
 	| union_head identifier '{'
-		{ $$ = start_struct (UNION_TYPE, $2); }
+		{ $<ttype>$ = start_struct (UNION_TYPE, $2); }
 	  component_decl_list '}' maybe_attribute
 		{ $$ = finish_struct ($<ttype>4, nreverse ($5),
 				      chainon ($1, $7)); }
@@ -1667,12 +1667,12 @@ structsp_attr:
 				      nreverse ($3), chainon ($1, $5));
 		}
 	| enum_head identifier '{'
-		{ $$ = start_enum ($2); }
+		{ $<ttype>$ = start_enum ($2); }
 	  enumlist maybecomma_warn '}' maybe_attribute
 		{ $$ = finish_enum ($<ttype>4, nreverse ($5),
 				    chainon ($1, $8)); }
 	| enum_head '{'
-		{ $$ = start_enum (NULL_TREE); }
+		{ $<ttype>$ = start_enum (NULL_TREE); }
 	  enumlist maybecomma_warn '}' maybe_attribute
 		{ $$ = finish_enum ($<ttype>3, nreverse ($4),
 				    chainon ($1, $7)); }
@@ -2135,7 +2135,7 @@ do_stmt_start:
 
 save_location:
 		{ if (yychar == YYEMPTY)
-		    yychar = YYLEX;
+		    yychar = yylex();
 		  $$ = input_location; }
 	;
 

--- a/toolchain/gcc/gcc/dwarf2out.c
+++ b/toolchain/gcc/gcc/dwarf2out.c
@@ -8256,7 +8256,7 @@ mem_loc_descriptor (rtx rtl, enum machine_mode mode)
 	 up an entire register.  For now, just assume that it is
 	 legitimate to make the Dwarf info refer to the whole register which
 	 contains the given subreg.  */
-      rtl = SUBREG_REG (rtl);
+      rtl = XEXP (rtl,0);
 
       /* ... fall through ...  */
 
@@ -8450,7 +8450,7 @@ loc_descriptor (rtx rtl)
 	 up an entire register.  For now, just assume that it is
 	 legitimate to make the Dwarf info refer to the whole register which
 	 contains the given subreg.  */
-      rtl = SUBREG_REG (rtl);
+      rtl = XEXP (rtl,0);
 
       /* ... fall through ...  */
 


### PR DESCRIPTION
The toolchain's suffered some bit rot, and on newer Linux installations changes to makeinfo and bison have broken the build process.  In addition, there's a buffer overflow bug in binutils which breaks the build process unless Fortify is disabled.

These patches work around these problems by disabling texinfo documentation if makeinfo is too new, disabling Fortify before building binutils, and fixing c-parse.y.

In addition, an obscure "internal compiler error" is fixed, which I encountered when using varargs in code when debugging symbols were enabled.